### PR TITLE
[명다연]2주차 BFS/DFS 문제 커밋: 네트워크,단어변환,타겟넘버,단지번호붙이기,DFS와 BFS, 여행경로,바이러스,숨바꼭질,미로탐색

### DIFF
--- a/myeong_da_yeon/week2/1260_DFS와_BFS.java
+++ b/myeong_da_yeon/week2/1260_DFS와_BFS.java
@@ -1,0 +1,78 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+import java.util.Collections;
+
+class Main
+{
+
+   
+    static ArrayList<ArrayList<Integer>> arr = new ArrayList<>();
+    static int[] ch;
+    public static void main (String[] args) throws java.lang.Exception
+    {
+        
+        System.setIn(new FileInputStream("input.txt"));
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int v = Integer.parseInt(st.nextToken());
+        
+        ch = new int[n+1];
+
+        //인접리스트
+        for(int i = 0;i<n+1;i++) {
+            arr.add(new ArrayList<Integer>());
+        }
+
+        for(int i = 0;i<m;i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            arr.get(a).add(b);
+            arr.get(b).add(a);
+        }
+        //이동경로가 작은 순
+        for(int i = 0;i<arr.size();i++) {
+            Collections.sort(arr.get(i));
+        }
+
+        //dfs
+        dfs(v);
+        System.out.print("\n");
+        //bfs
+        
+        ch = new int[n+1];
+        bfs(v);
+    }
+
+    static void dfs(int v) {
+        System.out.print(v + " ");
+        ch[v] = 1;
+        for(int i = 0;i<arr.get(v).size();i++) {
+            if(ch[arr.get(v).get(i)] == 0) {
+                dfs(arr.get(v).get(i));
+            }
+        }
+    }
+
+    static void bfs(int v) {
+        Queue<Integer> q = new LinkedList<>();
+        ch[v] = 1;
+        q.add(v);
+        while(!q.isEmpty()) {
+            int x = q.poll();
+            System.out.print(x + " ");
+            for(int i = 0;i<arr.get(x).size();i++) {
+                if(ch[arr.get(x).get(i)] == 0) {
+                    ch[arr.get(x).get(i)] = 1;
+                    q.add(arr.get(x).get(i));
+                }
+            }
+        }
+    }
+}

--- a/myeong_da_yeon/week2/1697_숨바꼭질.java
+++ b/myeong_da_yeon/week2/1697_숨바꼭질.java
@@ -1,0 +1,60 @@
+
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+import java.util.StringTokenizer;
+import java.util.ArrayList;
+
+class Main {
+    static int N;
+    static int K;
+    static int[] check = new int[100001];
+
+    public static void main(String[] args) {
+        
+       // System.setIn(new FileInputStream("input.txt"));
+
+        Scanner sc = new Scanner(System.in);
+        N = sc.nextInt();
+        K = sc.nextInt();
+
+        if (N == K) {
+            System.out.println(0);
+        } else {
+            bfs(N);
+        }
+    }
+
+    static void bfs(int num) {
+        Queue<Integer> q = new LinkedList<>();
+        q.add(num);
+        check[num] = 0;
+
+        while (!q.isEmpty()) {
+            int temp = q.poll();
+
+            if (temp == K) {
+                System.out.println(check[temp]);
+                return;
+            }
+            for (int i = 0; i < 3; i++) {
+                int next;
+
+                if (i == 0) {
+                    next = temp + 1;
+                } else if (i == 1) {
+                    next = temp - 1;
+                } else {
+                    next = temp * 2;
+                }
+
+                
+
+                if (next >= 0 && next < check.length && check[next] == 0) {
+                    q.add(next);
+                    check[next] = check[temp] + 1;
+                }
+            }
+        }
+    }
+}

--- a/myeong_da_yeon/week2/2178_미로탐색.java
+++ b/myeong_da_yeon/week2/2178_미로탐색.java
@@ -1,0 +1,84 @@
+/* 1707. 이분 그래프 (dfs) */
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+import java.util.StringTokenizer;
+import java.util.ArrayList;
+
+class Main
+{
+
+    static int n,m;
+    static int[] dx = {1,0,-1,0};
+    static int[] dy = {0,1,0,-1};
+    
+    public static void main (String[] args) throws java.lang.Exception
+    {
+        
+        System.setIn(new FileInputStream("input.txt"));
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        int[][] map = new int[n][m];
+        int[][] ch = new int[n][m];
+
+        for(int i = 0;i<n;i++) {
+            String str = br.readLine();
+            for(int j = 0;j<m;j++) {
+                map[i][j] = str.charAt(j) - '0';
+            
+            }
+        }
+
+        Queue<Point> q = new LinkedList<>();
+        //0,0 -> n-1,m-1
+        ch[0][0] = 1;
+        q.add(new Point(0,0));
+
+        while(!q.isEmpty()) {
+            Point p = q.poll();
+            int x = p.x;
+            int y = p.y;
+            
+            if(x == n-1 && y == m-1) {
+                System.out.println(ch[p.x][p.y]);
+                return;
+            }
+            
+
+            for(int i = 0;i<4;i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                if(nx < 0 || nx >= n || ny < 0 || ny >= m) {
+                    continue;
+                }
+
+                if( map[nx][ny] == 1 && ch[nx][ny] == 0) {
+                    ch[nx][ny] = ch[x][y] + 1;
+                    q.add(new Point(nx,ny));
+
+
+                }
+
+            }
+        }
+
+    }
+}
+
+class Point {
+    int x;
+    int y;
+    
+
+    public Point (int x, int y ) {
+        this.x = x;
+        this.y = y;
+        
+    }
+}

--- a/myeong_da_yeon/week2/2606_바이러스.java
+++ b/myeong_da_yeon/week2/2606_바이러스.java
@@ -1,0 +1,62 @@
+/* 11724. 연결 요소의 개수 */
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+import java.util.StringTokenizer;
+import java.util.ArrayList;
+
+class Main
+{
+    static int n;
+    static int m;
+    static ArrayList<ArrayList<Integer>> arr = new ArrayList<>();
+    static boolean[] ch;
+    static int cnt;
+
+    public static void main (String[] args) throws java.lang.Exception
+    {
+        
+        System.setIn(new FileInputStream("input.txt"));
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        ch = new boolean[n+1];
+
+        st = new StringTokenizer(br.readLine());
+        m = Integer.parseInt(st.nextToken());
+
+        for(int i = 0;i<n+1;i++) {
+            arr.add(new ArrayList<Integer>());
+        }
+        
+
+        for(int i = 0;i<m;i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            arr.get(a).add(b);
+            arr.get(b).add(a);
+        }
+    
+        cnt = 0;
+        ch[1] = true;
+        dfs(1);
+
+        System.out.println(cnt);
+    
+    }
+
+    static void dfs(int l) {
+
+        for(int i = 0;i<arr.get(l).size();i++) {
+            if(!ch[arr.get(l).get(i)]) {
+                ch[arr.get(l).get(i)] = true;
+                cnt++;
+                dfs(arr.get(l).get(i));
+
+            }
+        }
+    }
+}

--- a/myeong_da_yeon/week2/2667_단지번호붙이기.java
+++ b/myeong_da_yeon/week2/2667_단지번호붙이기.java
@@ -1,0 +1,100 @@
+/* 1712_손익분기점 */
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+import java.util.StringTokenizer;
+import java.util.ArrayList;
+
+class Main
+{
+    static int[] dx = {0,1,0,-1};
+    static int[] dy = {1,0,-1,0};
+    static int[][] map;
+    static int[][] ch;
+    static int n;
+    static ArrayList<Integer> arr = new ArrayList<>();
+
+    public static void main (String[] args) throws java.lang.Exception
+    {
+        
+        System.setIn(new FileInputStream("input.txt"));
+        
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+    
+        map = new int[n][n];
+        ch = new int[n][n];
+
+        for(int i = 0;i<n;i++) {
+            String str = br.readLine();
+            for(int j = 0;j<n;j++) {
+                map[i][j] = str.charAt(j)-'0';
+            }
+        }
+
+        int idx = 0;
+
+        for(int i = 0;i<n;i++) {
+            for(int j = 0;j<n;j++) {
+                if(map[i][j] == 1 && ch[i][j] == 0) {
+                    ++idx;
+                    arr.add(bfs(i,j));
+                }
+            }
+        }
+
+        Collections.sort(arr);
+
+        System.out.println(idx);
+        
+        for(int i = 0;i<arr.size();i++) {
+            System.out.println(arr.get(i));
+        }
+
+    }
+
+    static int bfs(int a,int b) {
+        Queue<Point> q = new LinkedList<>();
+        ch[a][b] = 1;
+        int cnt = 1;
+        q.add(new Point(a,b));
+        
+
+        while(!q.isEmpty()) {
+            Point p = q.poll();
+            int x = p.x;
+            int y = p.y;
+
+            for(int i = 0;i<4;i++) {
+                int nx = x+dx[i];
+                int ny = y+dy[i];
+
+                if(nx < 0 || nx >=n || ny < 0 || ny >= n) {
+                    continue;
+                }
+
+                if(ch[nx][ny] == 0 && map[nx][ny] == 1) {
+                    ch[nx][ny] = 1;
+                    q.add(new Point(nx,ny));
+                    cnt++;
+                }
+            }
+
+
+        }
+
+        return cnt;
+
+    }
+}
+
+class Point {
+    int x;
+    int y;
+
+    public Point(int x,int y) {
+        this.x = x;
+        this.y = y;
+    }
+}

--- a/myeong_da_yeon/week2/네트워크.java
+++ b/myeong_da_yeon/week2/네트워크.java
@@ -33,16 +33,16 @@ class Solution {
         for(int i = 0;i<tmp.length;i++) {
             tmp[i]  = i;    
         }
-        
-        for(int i = 0;i<computers.length;i++) {
-            for(int j = 0;j<computers[i].length;j++) {
+        //절반
+        for(int i = 0;i<computers.length-1;i++) {
+            for(int j = i+1;j<computers[i].length;j++) {
+               
+                
                 if(computers[i][j] == 1) {
-                    if(i == j) {
-                        continue;
-                    } else {
+                    
                     
                         union(i,j);
-                    }
+                    
                 
                 }
             }
@@ -70,7 +70,7 @@ class Solution {
         if(v == tmp[v]) {
             return v;
         } else {
-            return find(tmp[v]);
+            return tmp[v] = find(tmp[v]);
         }
     }
 }

--- a/myeong_da_yeon/week2/네트워크.java
+++ b/myeong_da_yeon/week2/네트워크.java
@@ -1,0 +1,76 @@
+import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.HashSet;
+
+class Main
+{
+    public static void main (String[] args) throws java.lang.Exception
+    {
+      
+        int[][] computers = {{1,1,0},{1,1,0},{0,0,1}};
+        int n = 3;
+        Solution sol  = new Solution();
+        int ans = sol.solution(n, computers);
+        System.out.println(ans);
+    }
+}
+
+class Solution {
+    
+    static int[] tmp;
+    
+    public int solution(int n, int[][] computers) {
+        tmp = new int[computers.length];
+        
+        for(int i = 0;i<tmp.length;i++) {
+            tmp[i]  = i;    
+        }
+        
+        for(int i = 0;i<computers.length;i++) {
+            for(int j = 0;j<computers[i].length;j++) {
+                if(computers[i][j] == 1) {
+                    if(i == j) {
+                        continue;
+                    } else {
+                    
+                        union(i,j);
+                    }
+                
+                }
+            }
+        }
+        
+        HashSet<Integer> hs = new HashSet<>();
+        
+        for(int i = 0;i<tmp.length;i++) {
+                hs.add(find(i));
+        }
+        
+        return hs.size();
+    }
+    
+    static void union(int x, int y) {
+        x = find(x);
+        y = find(y);
+    
+        if(x != y) {
+            tmp[x] = y;
+        }
+    }
+    
+    static int find(int v) {
+        if(v == tmp[v]) {
+            return v;
+        } else {
+            return find(tmp[v]);
+        }
+    }
+}

--- a/myeong_da_yeon/week2/단어변환.java
+++ b/myeong_da_yeon/week2/단어변환.java
@@ -1,0 +1,85 @@
+import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.HashSet;
+
+class Main
+{
+    public static void main (String[] args) throws java.lang.Exception
+    {
+      
+        String begin = "hit";
+        String target = "cog";
+        String[] words = {"hot", "dot", "dog", "lot", "log", "cog"};
+        Solution sol  = new Solution();
+        int ans = sol.solution(begin,target,words);
+        System.out.println(ans);
+    }
+}
+
+class Solution {
+    public int solution(String begin, String target, String[] words) {
+        int answer = 0;
+        Queue<Point> q = new LinkedList<>();
+        HashMap<String,Integer> hm = new HashMap<>();
+        
+        hm.put(begin,1);
+        q.add(new Point(begin,0));
+        
+        while(!q.isEmpty()) {
+            Point p = q.poll();
+           
+            
+            if(target.equals(p.str)) {
+                answer = p.cnt;
+                break;
+            }
+            
+            for(int i = 0;i<words.length;i++) {
+                
+                if(hm.get(words[i]) == null && check(p.str, words[i])) {
+                    hm.put(words[i],1);
+                    q.add(new Point(words[i],p.cnt+1));
+                    
+                }
+            }
+            
+        }
+        
+        
+        return answer;
+    }
+    
+    boolean check(String str, String qStr) {
+        
+        int cnt = 0;
+        for(int i = 0;i<str.length();i++) {
+            
+            if(str.charAt(i) != qStr.charAt(i)) {
+                cnt++;
+            }
+        }
+        
+        if(cnt == 1) {
+          return true;  
+        } 
+        
+        return false;
+    }
+}
+class Point {
+    String str;
+    int cnt;
+    
+    public Point(String str,int cnt) {
+        this.str = str;
+        this.cnt = cnt;
+    }
+}

--- a/myeong_da_yeon/week2/여행경로.java
+++ b/myeong_da_yeon/week2/여행경로.java
@@ -1,0 +1,54 @@
+import java.util.*;
+
+class Solution {
+    
+    static boolean[] check;
+   
+    static ArrayList<String> arr = new ArrayList<>();
+    
+    public String[] solution(String[][] tickets) {
+        
+        String ans = "";
+        check = new boolean[tickets.length];
+        
+        ans += "ICN,";
+        for(int i = 0;i<tickets.length;i++) {
+            //ICN정점부터 시작
+            
+            if(tickets[i][0].equals("ICN") && !check[i]) {
+                ans+=(tickets[i][1]+",");
+                
+                check[i] = true;
+                dfs(tickets[i][1],1,tickets,ans);
+                check[i] = false;
+                ans = ans.substring(0,ans.length()-4);
+                 
+            }
+        }
+        
+        Collections.sort(arr);
+        
+        String[] answer = arr.get(0).split(",");
+        
+        return answer;
+    }
+    static void dfs(String v, int cnt,String[][] tickets,String ans) {
+        
+        if(cnt == tickets.length) {
+            
+            arr.add(ans);
+            return;
+        } 
+        
+        for(int i = 0;i<tickets.length;i++) {
+            if(tickets[i][0].equals(v) && !check[i]) {
+                
+                ans += (tickets[i][1]+",");
+                check[i] = true;
+                dfs(tickets[i][1],cnt+1,tickets,ans);
+                check[i] = false;
+                ans = ans.substring(0,ans.length()-4);
+            }
+        }
+    }
+}

--- a/myeong_da_yeon/week2/타겟넘버.java
+++ b/myeong_da_yeon/week2/타겟넘버.java
@@ -1,0 +1,48 @@
+import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.HashSet;
+
+class Main
+{
+    public static void main (String[] args) throws java.lang.Exception
+    {
+      
+        int[] numbers = {1,1,1,1,1};
+        
+        Solution sol  = new Solution();
+        int ans = sol.solution(numbers,3);
+        System.out.println(ans);
+    }
+}
+
+class Solution {
+    static int answer = 0;
+    public int solution(int[] numbers, int target) {
+        
+        dfs(0,0,numbers,target);
+
+        return answer;
+    }
+
+    static void dfs(int idx, int sum,int[] numbers,int target) {
+        if(idx == numbers.length) {
+
+            if(sum == target) {
+                answer++;
+            }
+            return;
+        }
+
+        dfs(idx+1,sum + numbers[idx], numbers,target);
+
+        dfs(idx+1,sum - numbers[idx], numbers,target);
+    }        
+}


### PR DESCRIPTION
### 네트워크
**풀이 설명**
union find 알고리즘 이용해서 품. 연결된 노드 a,b가 있을 때 tmp[a] = b로 표현하여 자식노드의 값을 부모노드로 연결해준다.   그리고 hashset은 중복값과 순서가 보장되지 않는 콜렉션 프레임워크인데 hashset에 부모노드의 값을 담고 중복값은 제외한다..설명 어케해..하..

**시간복잡도** 
n 
computers 사이즈의 절반 = (n*n/2)
union 함수 :  연결된 간선수만큼 
find 함수 : 상수
-> n^2(2중 for문 n * union n) + n(find n) + hashset

### 단어변환
**풀이 설명**
bfs , 큐에 begin 문자를 넣는다. begin문자에서 갈 수 있는 문자들은 words배열에 있는 원소들 중에 문자가 하나만 다른 words값들이다.이를 check 메소드에서 확인하여 begin에서 갈 수 있는 문자를 큐에 넣는다. 큐에 넣을 때 몇단계의 과정을거쳤는지도 값을 넣어준다. 그리고 한번 큐에 넣은 값들은 다시 방문하지 않도록 중복 키값이 허용되지 않는 hashmap을 사용한다.(일반적으로 bfs에서 사용하던 ch배열의 역할을 하는 거)큐에서 빼면서 뺀 값이 target이랑 같으면 break해서 answer 출력

**시간복잡도**
if(hm.get().....)부분을 보면 정점 하나당 해당 코드가 실행하는데 words의 크기만큼 걸린다(O(N)). 게다가, 이 words 반복문은 while (!q.isEMpty) 코드를 통해 모든 정점을 한번씩 방문할때마다 v번 반복실행한다.

따라서, 인접 행렬방식의 BFS의 시간 복잡도 = V * O(V) = O(V^2).

### 타겟넘버
**풀이 설명**
주어진 모든 숫자에 +연산과 -연산을 하는 경우를 탐색하면서 타겟 숫자가 나오는 횟수를 카운트하면 된다. DFS 알고리즘을 이용하면 전체 숫자가 +,-일 모든 경우의 수를 탐색할 수 있다.

**시간복잡도**
 경우의 수를 고려해 보면 숫자 n개는 각각 +와 -가 될 수 있는 두가지 경우의 수를 가지고 있고, numbers배열의 크기인 모든 정점들이 모두  이 과정을 하므로 2 * 2 * 2 * ….. 과정을 n번, 총 2^N번의 탐색이 일어난다.

O(2^N)

### 단지번호 붙이기
**풀이 설명**
2차원 배열 map을 2중for문으로 돌면서 단지가 시작하는 지점부터 해당 단지가 끝날때까지(큐가 빌때까지) bfs를 함. 

**시간복잡도**
단지수만큼..?

### 여행경로
**풀이 설명**
ICN에서 도착점까지 갈 수 있는 지점들을 dfs로 방문하면서 문자열을 만들고 도착점에 도착하면 해당 문자열은 arraylist에 넣는다. ICN에서 도착점까지 갈 수 있는 모든 경우를 arraylist에 넣기때문에 이후에 arraylist를 오름차순으로 정렬하여 제일 문자열이 작은값인 첫번째 인덱스에 있는 arraylist값을 출력

**시간복잡도**
O(V+E),,,?

### BFS와 DFS
**풀이 설명**
인접리스트 방식의 dfs, bfs

**시간복잡도**
DFS : O(V+E)
BFS : O(V+E)

### 바이러스
**풀이 설명**
인접리스트방식으로 연결된 간선 정보를 다 저장하여 dfs 탐색하며 연결된 정점 개수 cnt변수로 셈

**시간복잡도**
1번에 연결된 정점들만 탐색,,하므로,,

### 숨바꼭질
**풀이 설명**
현재 위치에서 갈 수 있는 위치를 큐에 넣으면서 bfs 탐색

**시간복잡도**
큐에 담긴 모든 정점에서 각각 갈 수 있는 위치들을 확인한다

O(V+E)

### 미로탐색
**풀이 설명**
현재 위치에서 갈 수 있는 위치를 큐에 넣으면서 bfs 탐색,ch배열에 현재 위치까지의 거리를 넣는다.

**시간복잡도**
O(V+E)