### PR TITLE
[신지수_4주차] 토마토, 유기농배추, 벽 부수고 이동하기, 나이트의 이동, 7576 토마토, 연구소, 텀프로젝트

### DIFF
--- a/shin_jisoo/DFS&BFS_2/7576 토마토.cpp
+++ b/shin_jisoo/DFS&BFS_2/7576 토마토.cpp
@@ -1,0 +1,69 @@
+#include <iostream>
+#include <queue>
+using namespace std;
+
+#define MAX 101
+
+typedef struct {
+    int x, y, z;
+    int cnt;
+} types;
+
+int m, n, h;
+int box[MAX][MAX][MAX];
+bool visited[MAX][MAX][MAX];
+int dx[6] = { 1, -1, 0, 0, 0, 0 };
+int dy[6] = { 0, 0, 1, -1, 0, 0 };
+int dz[6] = { 0, 0, 0, 0, 1, -1 };
+queue<types> bfs;
+
+int main() {
+    int cnt = 0;
+
+    cin >> m >> n >> h;
+    for (int k = 0; k < h; k++)
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < m; j++) {
+                cin >> box[i][j][k];
+                if (box[i][j][k] == 1) {
+                    bfs.push({ i, j, k, 0 });
+                    visited[i][j][k] = true;
+                }
+                else if (box[i][j][k] == -1)
+                    visited[i][j][k] = true;
+            }
+
+    if (bfs.empty()) {
+        printf("-1");
+        return 0;
+    }
+
+    while (!bfs.empty()) {
+        auto cur = bfs.front();
+        bfs.pop();
+        cnt = max(cnt, cur.cnt);
+
+        for (int i = 0; i < 6; i++) {
+            int nx = cur.x + dx[i];
+            int ny = cur.y + dy[i];
+            int nz = cur.z + dz[i];
+
+            if (nx >= 0 && ny >= 0 && nz >= 0 && nx < n && ny < m && nz < h && !visited[nx][ny][nz]) {
+                bfs.push({ nx, ny, nz, cur.cnt + 1 });
+                visited[nx][ny][nz] = true;
+            }
+        }
+    }
+
+    for (int i = 0; i < n; i++)
+        for (int j = 0; j < m; j++)
+            for (int k = 0; k < h; k++)
+                if (!visited[i][j][k]) {
+                    cout << -1;
+                    return 0;
+                }
+
+    cout << cnt;
+    return 0;
+
+}

--- a/shin_jisoo/DFS&BFS_2/나이트의이동.cpp
+++ b/shin_jisoo/DFS&BFS_2/나이트의이동.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <queue>
+#include <cstring>
+using namespace std;
+
+#define MAX 301
+#define X first
+#define Y second
+
+int dx[8] = { 1,2,2,1,-1,-2,-2,-1 };
+int dy[8] = { 2,1,-1,-2,-2,-1,1,2 };
+
+int board[MAX][MAX];
+bool visited[MAX][MAX];
+
+int I;
+queue<pair<int, int>> Q;
+int src_x, src_y, dst_x, dst_y;
+
+void bfs(int a, int b) {
+	Q.push({ a,b });
+	visited[a][b] = true;
+
+	while (!Q.empty()) {
+		auto cur = Q.front(); Q.pop();
+		if (cur.X == dst_x && cur.Y == dst_y) {
+			cout << board[cur.X][cur.Y] << "\n";
+
+			while (!Q.empty()) Q.pop();
+
+			break;
+		}
+
+		for (int dir = 0;dir < 8;dir++) {
+			int nx = cur.X + dx[dir];
+			int ny = cur.Y + dy[dir];
+
+			if (nx >= 0 && nx < I && ny >= 0 && ny < I) {
+				if (visited[nx][ny] == false) {
+					visited[nx][ny] = true;
+					board[nx][ny] = board[cur.X][cur.Y] + 1;
+					Q.push({ nx,ny });
+				}
+			}
+		}
+	}
+}
+
+int main() {
+	int t;
+	cin >> t;
+
+	for (int i = 0;i < t;i++) {
+		cin >> I;
+		cin >> src_x >> src_y >> dst_x >> dst_y;
+		bfs(src_x, src_y);
+
+		memset(board, 0, sizeof(board));
+		memset(visited, false, sizeof(visited));
+	}
+	return 0;
+}

--- a/shin_jisoo/DFS&BFS_2/벽 부수고 이동하기.cpp
+++ b/shin_jisoo/DFS&BFS_2/벽 부수고 이동하기.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <queue>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+using namespace std;
+
+#define MAX 1001
+
+int n, m;
+int board[MAX][MAX];
+bool visit[MAX][MAX][2] = { false, };
+int dx[4] = { 1,0,-1,0 };
+int dy[4] = { 0,1,0,-1 };
+
+int bfs() {
+	queue<pair<pair<int, int>, pair<int, int>>>Q;
+	Q.push(make_pair(make_pair(0,0),make_pair(1,1)));
+	visit[0][0][1] = true;
+
+	while (!Q.empty()) {
+		int x = Q.front().first.first;
+		int y = Q.front().first.second;
+		int wall = Q.front().second.first;
+		int cnt = Q.front().second.second;
+		Q.pop();
+
+		if (x == n - 1 && y == m - 1)return cnt;
+		for (int dir = 0;dir < 4;dir++) {
+			int nx = x + dx[dir];
+			int ny = y + dy[dir];
+
+			if (nx < 0 || nx >= n || ny < 0 || ny >= m)continue;
+			if (board[nx][ny] == 1 && wall == 1) {
+				visit[nx][ny][wall] = true;
+				Q.push(make_pair(make_pair(nx, ny), make_pair(wall - 1, cnt + 1)));
+			}
+			if (board[nx][ny] == 0 && !visit[nx][ny][wall]) {
+				visit[nx][ny][wall] = true;
+				Q.push(make_pair(make_pair(nx, ny), make_pair(wall, cnt + 1)));
+			}
+		}
+	}
+	return -1;
+}
+
+int main() {
+	ios::sync_with_stdio(0);
+	cin.tie(0); cout.tie(0);
+
+	cin >> n >> m;
+
+	for (int i = 0;i < n;i++) {
+		string tmp;
+		cin >> tmp;
+		for (int j = 0;j < m;j++)
+			board[i][j] = tmp[j] - '0';
+	}
+	cout << bfs();
+	return 0;
+}

--- a/shin_jisoo/DFS&BFS_2/연구소.cpp
+++ b/shin_jisoo/DFS&BFS_2/연구소.cpp
@@ -1,0 +1,85 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+
+using namespace std;
+int answer = 0;
+
+int dx[4] = { 0, 0, 1, -1 };
+int dy[4] = { 1, -1, 0, 0 };
+
+void check_bfs(vector<vector<int>>& v) {
+	queue<pair<int, int>> Q;
+
+	for (int i = 0; i < v.size(); i++) {
+		for (int j = 0; j < v[i].size(); j++) {
+			if (v[i][j] == 2)
+				Q.push({ i,j });
+		}
+	}
+
+	while (!Q.empty()) {
+		int x = Q.front().first;
+		int y = Q.front().second;
+		Q.pop();
+		for (int i = 0; i < 4; i++) {
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+
+			if (nx > -1 && nx < v.size() && ny > -1 && ny < v[x].size() &&
+				v[nx][ny] == 0) {
+				Q.push({ nx,ny });
+				v[nx][ny] = 2;
+			}
+		}
+	}
+
+	int cnt = 0;
+	for (int i = 0; i < v.size(); i++) {
+		for (int j = 0; j < v[i].size(); j++) {
+			if (v[i][j] == 0)
+				cnt++;
+		}
+	}
+	answer = max(answer, cnt);
+}
+
+void dfs(vector<vector<int>> v, int x, int y, int cnt) {
+	v[x][y] = 1;
+
+	if (cnt == 0) {
+		check_bfs(v);
+		return;
+	}
+
+	for (int i = x; i < v.size(); i++) {
+		for (int j = 0; j < v[x].size(); j++) {
+			if (v[i][j] == 0)
+				dfs(v, i, j, cnt - 1);
+		}
+	}
+}
+
+int main() {
+	int n, a, b, m;
+
+	cin >> n >> m;
+
+	vector<vector<int>> v(n, vector<int>(m));
+
+	for (int i = 0; i < n; i++) {
+		for (int j = 0; j < m; j++)
+			cin >> v[i][j];
+	}
+
+	for (int i = 0; i < n; i++) {
+		for (int j = 0; j < m; j++) {
+			if (v[i][j] == 0)
+				dfs(v, i, j, 2);
+		}
+	}
+
+	cout << answer << "\n";
+	return 0;
+}

--- a/shin_jisoo/DFS&BFS_2/유기농배추.cpp
+++ b/shin_jisoo/DFS&BFS_2/유기농배추.cpp
@@ -1,0 +1,60 @@
+#include<iostream>
+#include<string.h>
+using namespace std;
+
+#define MAX 51
+
+int dx[4] = { 1, 0, -1, 0 };
+int dy[4] = { 0, 1, 0, -1 };
+int board[MAX][MAX];
+bool visit[MAX][MAX];
+int testcase;
+int N, M, num;
+
+void dfs(int x, int y) {
+	for (int i = 0; i < 4; i++) {
+		int nx = x + dx[i];
+		int ny = y + dy[i];
+
+		if (nx < 0 || ny < 0 || nx >= M || ny >= N) continue;
+
+		if (board[nx][ny] == 1 && !visit[nx][ny]) {
+			visit[nx][ny] = true;
+			dfs(nx, ny);
+		}
+	}
+}
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0); cout.tie(0);
+
+	cin >> testcase;
+
+	while (testcase--) {
+		int answer = 0;
+
+		memset(board, 0, sizeof(board));
+		memset(visit, false, sizeof(visit));
+
+		cin >> N >> M >> num;
+		for (int i = 0; i < num; i++) {
+			int x, y;
+			cin >> y >> x;
+			board[x][y] = 1;
+		}
+
+		for (int i = 0; i < M; i++) {
+			for (int j = 0; j < N; j++) {
+				if (board[i][j] == 1 && !visit[i][j]) {
+					answer++;
+					visit[i][j] = true;
+					dfs(i, j);
+				}
+			}
+		}
+
+		cout << answer << "\n";
+	}
+	return 0;
+}

--- a/shin_jisoo/DFS&BFS_2/텀프로젝트.cpp
+++ b/shin_jisoo/DFS&BFS_2/텀프로젝트.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <cstring> //memset
+using namespace std;
+
+#define MAX 100001
+
+int n, cnt;
+int want[MAX];
+bool visited[MAX];
+bool done[MAX];
+
+void dfs(int nodeNum) {
+	visited[nodeNum] = true;
+
+	int next = want[nodeNum];
+	if (!visited[next]) dfs(next);
+
+	else if (!done[next]) {
+		for (int i = next;i != nodeNum;i = want[i]) cnt++;
+		cnt++;
+	}
+
+	done[nodeNum] = true;
+}
+
+int main() {
+	int t;
+	cin >> t;
+
+	for (int i = 0;i < t;i++) {
+		memset(visited, false, sizeof(visited));
+		memset(done, false, sizeof(done));
+		cin >> n;
+
+		for (int j = 1;j <= n;j++) {
+			cin >> want[j];
+		}
+		cnt = 0;
+		for (int j = 1;j <= n;j++) {
+			if (!visited[j]) dfs(j);
+		}
+
+		cout << n - cnt << "\n";
+	}
+	return 0;
+}

--- a/shin_jisoo/DFS&BFS_2/토마토.cpp
+++ b/shin_jisoo/DFS&BFS_2/토마토.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <queue>
+using namespace std;
+
+#define MAX 1002
+#define X first
+#define Y second
+
+int dx[4] = { 1,0,-1,0 };
+int dy[4] = { 0,1,0,-1 };
+int board[MAX][MAX];
+int dist[MAX][MAX];
+int n, m;
+
+int main() {
+	ios::sync_with_stdio(0);
+	cin.tie(0); cout.tie(0);
+
+	queue<pair<int, int>>Q;
+
+	cin >> m >> n;
+	for (int i = 0;i < n;i++) {
+		for (int j = 0;j < m;j++) {
+			cin >> board[i][j];
+			if (board[i][j] == 1)
+				Q.push({ i,j });
+			if (board[i][j] == 0)
+				dist[i][j] = -1;
+
+		}
+	}
+
+	while (!Q.empty()) {
+		auto cur = Q.front(); Q.pop();
+		for (int dir = 0;dir < 4;dir++) {
+			int nx = cur.X + dx[dir];
+			int ny = cur.Y + dy[dir];
+			if (nx < 0 || nx >= n || ny < 0 || ny >= m)continue;
+			if (dist[nx][ny] >= 0)continue;
+			dist[nx][ny] = dist[cur.X][cur.Y] + 1;
+			Q.push({ nx,ny });
+		}
+	}
+
+	int answer = 0;
+	for (int i = 0;i < n;i++) {
+		for (int j = 0;j < m;j++) {
+			if (dist[i][j] == -1) {
+				cout << -1;
+				return 0;
+			}
+			answer = max(answer, dist[i][j]);
+		}
+	}
+	cout << answer;
+}


### PR DESCRIPTION
### **유기농 배추**

- 풀이법 : dfs 사용
테스트 케이스가 바뀔 때마다 memset을 이용해 초기화
1) main 함수 : 배추가 있는 좌표를 board에 1로 표시
배추가 있고, 방문을 하지 않았을 경우 지렁이 횟수 증가(배추 더미를 처음 카운트 하는거니까)
2) dfs 함수 : 배열의 인덱스가 넘어가지 않고, 배추가 있고, 방문을 안했다면 재귀 호출

- 시간 복잡도 : O(nm)

### **토마토**

- 풀이법 : bfs 사용
토마토가 다 익기까지 필요한 최소 일수를 구하기 위해서는 모든 익지 않은 토마토들에 대해
가장 가깝게 위치한 익은 토마토까지의 거리를 구해야함.
익은 토마토가 여러개일 수 있으므로(즉, 시작점이 여러개)
익은 토마토를 큐에 넣고 큐에 있는 것을 하나씩 빼서 bfs 돌리기

- 시간 복잡도 : O(nm) 

### **벽 부수고 이동하기**

- 풀이법 : bfs 사용
queue에 x,y 값, 벽, 경로 길이 수를 한꺼번에 넣기
한번 진행할 때마다 cnt 증가
다음 진행하려는 배열의 값이 1일때, 벽의 값이 true 인 경우 벽 값을 false로 변경

- 시간 복잡도 : O(nm)

### **나이트의 이동**

- 풀이법 : bfs 사용(최소 이동 횟수 구하는 문제이므로)
board 에 출발치로부터 해당좌표 까지의 최소 이동 횟수를 담아놓음
도달했을 떄의 board 배열의 값을 출력하고 return

1) main 함수 : src(현재 좌표), dst(목적지 좌표)
테스트 케이스마다 memset을 이용해 배열 초기화
현재 좌표를 넣어 bfs 함수 호출
2) bfs 함수 : 현재 좌표를 queue에 넣고 방문표시
큐가 빌때까지 반복
목적지 좌표에 도달했을 경우 출력 후 큐비우고 return
도달하지 않았을 경우 배열에 벗어나지 않고, 방문하지 않은 것들을 bfs 탐색

- 시간 복잡도 : O(I^2)

### **7576 토마토**

- 풀이법 : 토마토에 높이만 추가

- 시간 복잡도 : O(nmh)

### **연구소**

- 풀이법 : bfs 사용(벽을 세울 수 있는 모든 경로를 탐색)
벽은 3개만 세울 수 있음
벽을 3개 세우고 세운 벽을 기준으로 바이러스를 퍼트린 후 남아있는 0의 개수를 구하기
모든 경우 중 0의 개수가 가장 많은 것을 출력

- 시간 복잡도 : O(2^n*2^m)

### **텀프로젝트**

- 풀이법 : dfs 사용
사이클을 이루지 않는 사람의 수 구하기
done 배열 : 더 이상 이 노드를 방문하지 않을 것이 확신하는 경우에만 true
이미 방문한 노드는 visited[노드] 로 표현
다시는 방문하지 않는 노드는 done[노드]로 표현
사이클에 포함된 노드들의 수를 더하고 전체 학생 수에서 빼면 답이 나옴
이미 방문했지만 방문이 끝난 노드가 아니라면
--> !visited[next] && !done[next] 로 구현
그랬을 경우 팀원을 모두 세고, 자기 자신도 센다음
done[nodeNum] = ture로 해주기.

- 시간 복잡도 : O(n)