### PR TITLE
[이혁수_4주차] 유기농배추, 달이차오른다, 트리의지름, 벽부수고이동하기, 텀프로젝트, 테트로미노, 미세먼지안녕

### DIFF
--- a/HyeokSoo/week4/01967_트리의지름.cpp
+++ b/HyeokSoo/week4/01967_트리의지름.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+using namespace std;
+
+struct edge{
+    int vertex;
+    int weight;
+};
+
+int n, maxW = -1, maxV;
+vector<vector<edge>> v(10001);
+bool visit[10001];
+
+void dfs(int curV, int curW){
+    visit[curV] = true;
+
+    int nextV, nextW;
+    for(int i=0;i<v[curV].size();++i){
+        nextV = v[curV][i].vertex;
+        nextW = curW + v[curV][i].weight;
+        if(!visit[nextV]){
+            if(maxW < nextW){
+                maxW = nextW;
+                maxV = nextV;
+            }
+
+            dfs(nextV, nextW);
+        }
+    }
+
+    visit[curV] = false;
+}
+
+int main() {
+    int v1, v2, w;
+
+    cin>>n;
+    for(int i=0;i<n-1;++i){
+        cin>>v1>>v2>>w;
+        v[v1].push_back({v2, w});
+        v[v2].push_back({v1, w});
+    }
+
+    dfs(1, 0);
+    maxW = 0;
+    dfs(maxV, 0);
+
+    cout<<maxW;
+    return 0;
+}
+
+// 증명 참고 - https://www.weeklyps.com/entry/%ED%8A%B8%EB%A6%AC%EC%9D%98-%EC%A7%80%EB%A6%84

--- a/HyeokSoo/week4/02206_벽부수고이동하기.cpp
+++ b/HyeokSoo/week4/02206_벽부수고이동하기.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+using namespace std;
+
+struct state{
+    int y;
+    int x;
+    int cnt;
+    int crash;
+};
+
+vector<string> map(1001, "x");
+int n, m;
+int dy[4] = {1, -1, 0, 0};
+int dx[4] = {0, 0, 1, -1};
+bool visit[1001][1001][2];
+
+int main() {
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    string str;
+    queue<state> q;
+    cin>>n>>m;
+
+    for(int i=1;i<=n;++i){
+        cin>>str;
+        map[i].append(str);
+    }
+
+    q.push({1, 1, 1, 0});
+    visit[1][1][0] = true;
+    int curY, curX, nextY, nextX, curCnt, curCrash;
+    char nextV;
+
+    while(!q.empty()){
+        curY = q.front().y;
+        curX = q.front().x;
+        curCnt = q.front().cnt;
+        curCrash = q.front().crash;
+        q.pop();
+
+        if(curY == n && curX == m){
+            cout<<curCnt;
+            return 0;
+        }
+
+        for(int i=0;i<4;++i){
+            nextY = curY + dy[i];
+            nextX = curX + dx[i];
+            nextV = map[nextY][nextX];
+
+            if(1 <= nextY && nextY <= n && 1 <= nextX && nextX <= m){
+                if(curCrash == 0){
+                    if(!visit[nextY][nextX][0]){
+                        if(nextV == '0'){
+                            q.push({nextY, nextX, curCnt+1, 0});
+                            visit[nextY][nextX][0] = true;
+                        }else {
+                            q.push({nextY, nextX, curCnt + 1, 1});
+                            visit[nextY][nextX][1] = true;
+                        }
+                    }
+                }else{
+                    if(!visit[nextY][nextX][1]){
+                        if(nextV == '0'){
+                            q.push({nextY, nextX, curCnt+1, 1});
+                            visit[nextY][nextX][1] = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    cout<<-1;
+    return 0;
+}
+

--- a/HyeokSoo/week4/09466_텀프로젝트.cpp
+++ b/HyeokSoo/week4/09466_텀프로젝트.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <memory.h>
+#include <vector>
+using namespace std;
+
+vector<pair<int, int>> v;
+bool visit[100001];
+bool visitEnd[100001];
+int t, n, num, cnt;
+
+void dfs(int cur, int seq){
+    visit[cur] = true;
+    v[cur].second = seq;
+    int nextP = v[cur].first;
+
+    if(!visit[nextP]){
+        dfs(nextP, seq+1);
+    }else{
+        if(!visitEnd[nextP]){
+            cnt += (seq - v[nextP].second + 1);
+        }
+    }
+
+    visitEnd[cur] = true;
+}
+
+int main() {
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    cin>>t;
+    for(int i=0;i<t;++i){
+        cin>>n;
+        memset(visit, false, 100001);
+        memset(visitEnd, false, 100001);
+        v.clear(); v.push_back({0, 0});
+        cnt = 0;
+
+        for(int j=1;j<=n;++j){
+            cin>>num;
+            v.push_back({num, 1});
+        }
+
+        for(int j=1;j<=n;++j){
+            if(!visit[j]){
+                dfs(j, 1);
+            }
+        }
+
+        cout<<n-cnt<<"\n";
+    }
+
+    return 0;
+}
+

--- a/HyeokSoo/week4/14500_테트로미노.cpp
+++ b/HyeokSoo/week4/14500_테트로미노.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+using namespace std;
+
+int dy[4] = {1, -1, 0, 0};
+int dx[4] = {0, 0, 1, -1};
+int board[500][500];
+int n, m, ans = -1;
+bool visit[500][500];
+vector<pair<int, int>> v;
+
+void calc(int y, int x, int cnt, int sum){
+    visit[y][x] = true;
+    v.push_back({y, x});
+    int curY, curX, nextY, nextX;
+
+    for(int i=0;i<v.size();++i){
+        curY = v[i].first;
+        curX = v[i].second;
+
+        for(int j=0;j<4;++j){
+            nextY = curY + dy[j];
+            nextX = curX + dx[j];
+
+            if(0 <= nextY && nextY < n && 0 <= nextX && nextX < m){
+                if(!visit[nextY][nextX]){
+                    if(cnt == 3){
+                        ans = max(ans, sum + board[nextY][nextX]);
+                        continue;
+                    }else{
+                        calc(nextY, nextX, cnt+1, sum + board[nextY][nextX]);
+                    }
+                }
+            }
+        }
+    }
+
+    v.pop_back();
+    visit[y][x] = false;
+}
+
+int main() {
+    cin>>n>>m;
+    for(int i=0;i<n;++i){
+        for(int j=0;j<m;++j){
+            cin>>board[i][j];
+        }
+    }
+
+    for(int i=0;i<n;++i){
+        for(int j=0;j<m;++j){
+            calc(i, j, 1, board[i][j]);
+        }
+    }
+
+    cout<<ans;
+    return 0;
+}
+

--- a/HyeokSoo/week4/17144_미세먼지.cpp
+++ b/HyeokSoo/week4/17144_미세먼지.cpp
@@ -1,0 +1,111 @@
+#include <iostream>
+#include <queue>
+using namespace std;
+
+struct info{
+    int y;
+    int x;
+    int amount;
+};
+
+int a[50][50];
+int r, c, t, cnt, ac1, ac2;
+int dr[4] = {1, -1, 0, 0};
+int dc[4] = {0, 0, 1, -1};
+queue<info> q;
+
+void spread(){
+    int nextR, nextC, val;
+
+    for(int i=0;i<r;++i){
+        for(int j=0;j<c;++j){
+            val = a[i][j];
+            if(((i == ac1 || i == ac2) && j == 0) || val == 0){
+                continue;
+            }
+
+            for(int k=0;k<4;++k){
+                nextR = i + dr[k];
+                nextC = j + dc[k];
+
+                if(0 <= nextR && nextR < r && 0 <= nextC && nextC < c){
+                    if((nextR == ac1 || nextR == ac2) && nextC == 0){
+                        continue;
+                    }
+
+                    q.push({nextR, nextC, val / 5});
+                    q.push({i, j, val / 5 * -1});
+                }
+            }
+        }
+    }
+
+    while(!q.empty()){
+        a[q.front().y][q.front().x] += q.front().amount;
+        q.pop();
+    }
+}
+
+void airCleaner(){
+    cnt -= a[ac1-1][0];
+    for(int i=ac1-1;i>0;--i){
+        a[i][0] = a[i-1][0];
+    }
+    for(int j=0;j<c-1;++j){
+        a[0][j] = a[0][j+1];
+    }
+    for(int i=0;i<ac1;++i){
+        a[i][c-1] = a[i+1][c-1];
+    }
+    for(int j=c-1;j>1;--j){
+        a[ac1][j] = a[ac1][j-1];
+    }
+    a[ac1][1] = 0;
+
+    cnt -= a[ac2+1][0];
+    for(int i=ac2+1;i<r-1;++i){
+        a[i][0] = a[i+1][0];
+    }
+    for(int j=0;j<c-1;++j){
+        a[r-1][j] = a[r-1][j+1];
+    }
+    for(int i=r-1;i>ac2;--i){
+        a[i][c-1] = a[i-1][c-1];
+    }
+    for(int j=c-1;j>1;--j){
+        a[ac2][j] = a[ac2][j-1];
+    }
+    a[ac2][1] = 0;
+}
+
+int main() {
+    int num;
+
+    cin>>r>>c>>t;
+    for(int i=0;i<r;++i){
+        for(int j=0;j<c;++j){
+            cin>>num;
+            a[i][j] = num;
+
+            if(num == -1){
+                if(ac1 == 0){
+                    ac1 = i;
+                }else{
+                    ac2 = i;
+                }
+
+            }else{
+                cnt += num;
+            }
+        }
+    }
+
+    for(int i=0;i<t;++i){
+        spread();
+        airCleaner();
+    }
+
+    cout<<cnt;
+    return 0;
+}
+


### PR DESCRIPTION
01012_유기농 배추
설명
입력받은 ground 맵을 순회하면서, 방문한 적 없는 1을 만나면 ++ans 처리를 해주고,
인접한 1을 모두 dfs 방식으로 탐색하여 방문처리를 해준다.

01194_달이차오른다가자
설명
미로찾기 문제에 조건을 추가한 문제. 때문에 기본적으로 bfs 방식으로 맵을 탐색하고,
잠긴 문에 도착했을 당시에, 키를 지니고 있는 지 확인하기 위해서는 계속해서 독립적인 키 소지 현황 정보도 넘겨줘야한다.
이를 간단하게 확인하기 위해서 비트마스킹을 적용하여 처리해주었고, 이후 처리는 일반 미로찾기 방식이랑 동일.

01967_트리의 지름
설명
원래는 양방향 트리 그래프에서 모든 경우의 노드 2개를 선택하여 거리를 구한 후 최대값을 찾는 방식 혹은
각 노드를 루트로 하여 가장 먼 노드를 찾고 그 중에서 가장 큰 값을 찾는 방식으로 구현하려 했는데,
시간초과가 날 것 같아서 풀이 방법을 참고하였다...구현은 쉬운데 입증과 설명이 불가능하다...
증명 참고 - https://www.weeklyps.com/entry/%ED%8A%B8%EB%A6%AC%EC%9D%98-%EC%A7%80%EB%A6%84

02206_벽 부수고 이동하기
설명
01194 문제와 유사하다. 조건은 더 쉬운 편!
방문을 체크하기 위한 3차원 배열을 만들어서, 자신이 현재 좌표에 도착했을 때가 벽을 부순 경우인지 아닌지를 구분하여 bfs로 탐방한다.

09466_텀 프로젝트
설명
연결관계 현황을 dfs로 탐색할 때, 2개의 방문 배열을 활용한다.
visit 배열은 처음 방문 했을 때 true가 되고,
visitEnd는 해당 방문 지점에 연결된 지점들 및 연결 관계를 재귀적으로 모두 탐색하였을 때 마지막에 true로 변경해준다.

따라서 어떤 지점을 dfs로 방문할 시에, visit이 false이면 처음 방문이기 때문에 계속해서 탐색을 이어 나가고,
어떠한 노드가 visit은 true && visitEnd은 false일 때, dfs를 통해 방문하게 되었을 때는 싸이클이 형성된 것이다.

dfs 인자로 현재 방문 중인 노드가, 일련의 조회 과정에서의 탐색 순서를 저장해 주고,
싸이클이 형성되었을 때, (현재 순서 - 재방문하게된 노드 기존의 순서 + 1) 은 한 싸이클의 구성 노드 수가 된다.

14500_테트로미노
설명
단순한 구현 문제.
문제의 조건이 복잡하지만, 잘 해석해보면 결국에는 모서리로 연속적으로 연결된 4개 블럭 값의 총합을 구하면 된다.
따라서 방문 처리와 현재 조사중일 때 포함된 블럭들을 관리해 주면서,

포함된 블럭이 4개 미만일 때에는 포함된 블럭들 중 한개를 선택하고, 인접한 4개의 블럭중 방문이 가능한 블럭을 포함시킨다.
포함된 블럭이 4개이면 총합을 구하고 최대값을 구해준다.

17144_미세먼지
설명
복잡한 구현 문제.
순차적으로 미세먼지의 확산을 구현하는데,
1 iter 가 끝나지 않았을 때에는, 순서상 뒤에 탐색하는 지점의 미세먼지 정보가 앞 서 확산한 미세먼지의 정보를 포함하면 안된다.
순차적으로 접근하지만 실제로는 동시에 진행되기 때문이다.
따라서 모든 확산 정보를 queue에 담아 기록하고, 1 iter 가 마무리 되면,
큐가 빌 때까지 모든 정보를 반영시켜준다.

또한 공기 청정기의 흐름도 방향에 주의해주면서 결과에 반영해준다.